### PR TITLE
changing disk_used_percentage definition

### DIFF
--- a/scripts/auto_upgrade.sh
+++ b/scripts/auto_upgrade.sh
@@ -280,7 +280,7 @@ fi
 geth_datadir=$(cat /etc/ethereum/geth.conf 2> /dev/null | awk -F'--datadir ' '{print $2}' | cut -d ' ' -f 1)
 
 # Current disk usage
-disk_used_percentage=$(df -lh 2> /dev/null | grep $(du -hs $geth_datadir 2> /dev/null | awk '{print $1}') | awk '{print $5}' | cut -d '%' -f 1)
+disk_used_percentage=$(df -lh 2> /dev/null | grep $(df -P $geth_datadir | awk 'END{print $1}') | awk '{print $5}' | cut -d '%' -f 1)
 logger "$PROCESS_NAME Geth disk usage reaches $disk_used_percentage%"
 
 # Check last prune timestamp

--- a/scripts/auto_upgrade.sh
+++ b/scripts/auto_upgrade.sh
@@ -280,7 +280,7 @@ fi
 geth_datadir=$(cat /etc/ethereum/geth.conf 2> /dev/null | awk -F'--datadir ' '{print $2}' | cut -d ' ' -f 1)
 
 # Current disk usage
-disk_used_percentage=$(df -lh 2> /dev/null | grep $(df -P $geth_datadir | awk 'END{print $1}') | awk '{print $5}' | cut -d '%' -f 1)
+disk_used_percentage=$(df $geth_datadir | awk 'END{print $5}' | cut -d '%' -f 1)
 logger "$PROCESS_NAME Geth disk usage reaches $disk_used_percentage%"
 
 # Check last prune timestamp

--- a/scripts/auto_upgrade.sh
+++ b/scripts/auto_upgrade.sh
@@ -320,7 +320,7 @@ if [[ $geth_is_running && $geth_is_prune_time = true && $disk_used_percentage -g
   discord_notify $PROCESS_NAME "Geth prune-state is completed."
 
   # Check disk usage after prune
-  disk_used_percentage=$(df -lh 2> /dev/null | grep $(du -hs $geth_datadir 2> /dev/null | awk '{print $1}') | awk '{print $5}' | cut -d '%' -f 1)
+  disk_used_percentage=$(df $geth_datadir | awk 'END{print $5}' | cut -d '%' -f 1)
   
   if [ $disk_used_percentage -ge $GETH_PRUNE_AT_PERCENTAGE ]; then
     # Remove file to stop prunning again until disk capacity is under the threshold


### PR DESCRIPTION
Originally the variable is set by looking for the data directory's size then grepping it against disk usage size. 

`du -hs $geth_datadir 2> /dev/null | awk '{print $1}'` this gives a size. Like 1.5T.

However, if there is a difference like 1.5T vs 1.6T, then the 1.5T can't be found in the output of df -lh and the rest of the grepping and piping breaks. 

`df -lh 2> /dev/null` this was giving me 1.6T, so there was no match in the grep operation.

In the proposed code change, we are instead looking for the disk name where the datadir is.

`df -P $geth_datadir | awk 'END{print $1}'` this gives something like `/dev/nvme0n1p2`

And from there we look for disk name in the output of df -lh. This should be more robust as disk names don't change unlike size and it's pretty much a sure thing to find the disk name that contains the datadir.